### PR TITLE
v0.2.29: Sync folders between stations on local network.

### DIFF
--- a/Borg.psd1
+++ b/Borg.psd1
@@ -1,6 +1,6 @@
 @{
     RootModule        = 'Borg.psm1'
-    ModuleVersion     = '0.2.28'
+    ModuleVersion     = '0.2.29'
     GUID              = 'f23e3f2e-a121-4c62-8913-ef4b1c946bcc'
     Author            = 'Andi Oliver Ion'
     CompanyName       = ''

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned -Force
 | `borg run`                  | N/A                       | Browse and execute a script from the custom scripts folder using fzf |
 | `borg run add`             | N/A                       | Add a `.ps1` script from current folder to your custom script folder, with overwrite confirmation |
 | `borg store`                | N/A                       | Opens your `store.json` config in Micro            |
+| `borg sync`                 | `upload/download`         | Synchronizes predefined folders between your station and a shared network location. The upload action mirrors local folders to the network hub (overwriting the remote copy), while download retrieves the latest versions from the hub back into the local environment. Configured via the Sync section in store.json. |
 | `borg sys restart`          | `sr`                      | Gracefully restarts the current station; useful for mobile-triggered restarts |
 | `borg sys shutdown`         | `ssd`                     | Gracefully shuts down the current station; useful for mobile-triggered shutdowns |
 | `borg update`               | N/A                       | Update the BORG module from PowerShell Gallery     |
@@ -254,6 +255,59 @@ You can:
 This way, all plugins remain part of the main project and benefit the entire community.
 
 ---
+
+### 🔄 Synchronizing Configuration Across Stations
+
+The **Sync** system allows you to keep your Borg setup consistent across multiple stations — for example, between **Thanatos** and **MasterChief** — using a shared network folder as a central hub.
+
+#### How It Works
+The mechanism is defined under the `Sync` section in your `store.json` and includes:
+- A single **NetworkRoot**: the shared location (e.g., `\\SERVER\Share\BorgHub`) that acts as the central repository.
+- A list of **Folders**: each maps a local path on your station to a relative subfolder inside the `NetworkRoot`.
+
+When you run:
+```powershell
+borg sync upload
+```
+Borg mirrors your local folders to the shared network hub (overwriting the remote copies).  
+When you run:
+```powershell
+borg sync download
+```
+it mirrors the shared hub contents back to your local station.
+
+This makes it effortless to move between workstations while preserving notes, ideas, configurations, and custom scripts.
+
+#### Example `store.json` Section
+```jsonc
+"Sync": {
+  "General": {
+    "NetworkRoot": "\\someremote\somesharedfolder"
+  },
+  "Folders": [
+    {
+      "Name": "borg-appdata",
+      "Local": "%APPDATA%\\Borg",
+      "Remote": "appdata",
+      "Exclude": ["*.log", "temp\\**", "logs\\**"]
+    },
+    {
+      "Name": "custom-scripts",
+      "Local": "C:\\custom-scripts",
+      "Remote": "custom-scripts"
+    }
+  ]
+}
+```
+
+#### Notes
+- Borg uses **robocopy** internally for maximum reliability, one retry (`/R:1`) and zero wait (`/W:0`).
+- The operation includes deletions to maintain an exact mirror.
+- Exclude patterns help skip logs, temporary folders, or transient files.
+- No extra software is required — it runs entirely through PowerShell.
+
+---
+
 
 ### ✅ Guidelines for Writing Plugins
 - Scripts should be **PowerShell `.ps1` files**.  
@@ -499,6 +553,7 @@ To clean it from your profile:
 - [x] Borg notes (notes that remains until deleted and are easy searchable)
 - [x] Borg web quick jump to urls
 - [x] Borg gpt prompt + files
+- [x] Sync folders between stations in a local network
 ---
 
 ## 🖧 SSH Setup for Borg on Windows Stations

--- a/borg.ps1
+++ b/borg.ps1
@@ -19,16 +19,16 @@ function GetLatestReleaseNoteFile {
     $pattern = '^(?<ver>\d+(?:\.\d+){1,3})(?:\.?md|\.?markdown)$'
 
     $candidates = Get-ChildItem -LiteralPath $Folder -File -ErrorAction SilentlyContinue |
-        Where-Object { $_.Name -match $pattern } |
-        ForEach-Object {
-            $ver = $null
-            if ([Version]::TryParse($Matches['ver'], [ref]$ver)) {
-                [pscustomobject]@{
-                    Version = $ver
-                    File    = $_
-                }
+    Where-Object { $_.Name -match $pattern } |
+    ForEach-Object {
+        $ver = $null
+        if ([Version]::TryParse($Matches['ver'], [ref]$ver)) {
+            [pscustomobject]@{
+                Version = $ver
+                File    = $_
             }
         }
+    }
 
     if (-not $candidates) { return $null }
 
@@ -60,6 +60,28 @@ function ShowReleaseNotes {
 
     Write-Host "=========================`n" -ForegroundColor Cyan
 }
+function Test-DockerRunning {
+    $dockerRunning = $false
+    try {
+        $null = docker info --format '{{.ServerVersion}}' 2>$null
+        if ($LASTEXITCODE -eq 0) {
+            $dockerRunning = $true
+        }
+    }
+    catch {
+        # ignored
+    }
+
+    if ($dockerRunning) {
+        Write-Host "🐳  Docker is running." -ForegroundColor Cyan
+    }
+    else {
+        Write-Warning "⚠️  Docker daemon not detected. Some Borg Docker commands may be unavailable."
+    }
+
+    return $dockerRunning
+}
+
 function _InvokeBorgEntry {
     # Parse raw tokens (no named params on purpose)
     [string]$module = $null
@@ -103,13 +125,8 @@ function _InvokeBorgEntry {
         exit 1
     }
 
-    try {
-        docker info --format '{{.ServerVersion}}' | Out-Null
-    }
-    catch {
-        Write-Warning "Docker daemon does not appear to be running. Start Docker Desktop and try again."
-        exit 1
-    }
+    # Check if Docker is running (no console errors, no breaking flow)
+    Test-DockerRunning | Out-Null
 
     # --- Self version info ---
     if ($args -contains '--version' -or $args -contains '-v') {
@@ -158,9 +175,9 @@ function _InvokeBorgEntry {
 
         $map = @{
             # Two-word combos FIRST (highest precedence)
-            "b gl" = "git log"
-            "b gs" = "git status"
-            "b b"  = "bookmark"   # legacy muscle-memory: `b b` == `bookmark`
+            "b gl"  = "git log"
+            "b gs"  = "git status"
+            "b b"   = "bookmark"   # legacy muscle-memory: `b b` == `bookmark`
             
             # One-word aliases
             "b"     = "bookmark"
@@ -172,7 +189,7 @@ function _InvokeBorgEntry {
             "du"    = "docker upload"
             "ds"    = "docker switch"
             "dsnap" = "docker snapshot"
-            "ne"     = "network"
+            "ne"    = "network"
             "js"    = "jump store"
             "iofc"  = "io folder-clean"
             "ssd"   = "sys shutdown"
@@ -190,8 +207,8 @@ function _InvokeBorgEntry {
         $oneKey = $Tokens[0].ToLower()
 
         # Remainders
-        $rest2  = if ($Tokens.Count -gt 2) { $Tokens[2..($Tokens.Count-1)] } else { @() }
-        $rest1  = if ($Tokens.Count -gt 1) { $Tokens[1..($Tokens.Count-1)] } else { @() }
+        $rest2 = if ($Tokens.Count -gt 2) { $Tokens[2..($Tokens.Count - 1)] } else { @() }
+        $rest1 = if ($Tokens.Count -gt 1) { $Tokens[1..($Tokens.Count - 1)] } else { @() }
 
         if ($twoKey -and $map.ContainsKey($twoKey)) {
             $repl = $map[$twoKey] -split ' '
@@ -206,8 +223,8 @@ function _InvokeBorgEntry {
 
     # Build full token list from what the user typed
     $tokens = @()
-    if ($module)    { $tokens += $module }
-    if ($command)   { $tokens += $command }
+    if ($module) { $tokens += $module }
+    if ($command) { $tokens += $command }
     if ($extraArgs) { $tokens += $extraArgs }
 
     # Resolve aliases
@@ -216,8 +233,8 @@ function _InvokeBorgEntry {
     $resolved = @($resolved | ForEach-Object { $_.ToString().Trim() } | Where-Object { $_ -ne "" })
 
     # Re-split into module / command / extraArgs
-    $module    = if ($resolved.Count -ge 1) { $resolved[0] } else { $null }
-    $command   = if ($resolved.Count -ge 2) { $resolved[1] } else { $null }
+    $module = if ($resolved.Count -ge 1) { $resolved[0] } else { $null }
+    $command = if ($resolved.Count -ge 2) { $resolved[1] } else { $null }
     $extraArgs = if ($resolved.Count -gt 2) { $resolved[2..($resolved.Count - 1)] } else { @() }
 
     # Hand off to main entry

--- a/borg.ps1
+++ b/borg.ps1
@@ -73,7 +73,8 @@ function Test-DockerRunning {
     }
 
     if ($dockerRunning) {
-        Write-Host "🐳  Docker is running." -ForegroundColor Cyan
+        # do nothing for the moment, a bit annoying while using.
+        # Write-Host "🐳  Docker is running." -ForegroundColor Cyan
     }
     else {
         Write-Warning "⚠️  Docker daemon not detected. Some Borg Docker commands may be unavailable."

--- a/data/store.example.json
+++ b/data/store.example.json
@@ -29,6 +29,28 @@
         "SqlBackupDefault": "C:\\sql-backups",
         "CustomScripts": "C:\\custom-scripts"
     },
+    "Sync": {
+        "General": {
+            "NetworkRoot": "\\\\someremote\\somesharedfolder"
+        },
+        "Folders": [            
+            {
+                "Name": "custom-scripts",
+                "Local": "C:\\custom-scripts",
+                "Remote": "custom-scripts"
+            },
+            {
+                "Name": "otherfolder",
+                "Local": "c:\\other-folder",
+                "Remote": "other-folder",
+                "Exclude": [
+                    "*.log",
+                    "temp\\**",
+                    "logs\\**"
+                ]
+            }
+        ]
+    },
     "SqlServers": [
         {
             "Name": "ThanatosDocker",
@@ -61,20 +83,17 @@
         "Engine": "gpt",
         "SystemPrompt": "You are a concise senior engineer. Prefer interfaces, avoid cascading ifs, respect team style; minimal intervention on C# '..' spread-like syntax; give actionable outputs.",
         "Timezone": "Europe/Bucharest",
-        
         "GptBaseUrl": "https://api.openai.com/v1",
         "GptModel": "gpt-4o-mini",
         "GptApiKey": "your api key",
         "GptTemperature": 0.2,
         "GptMaxOutputTokens": 1200,
-        
         "ClaudeBaseUrl": "https://api.anthropic.com",
         "ClaudeModel": "claude-opus-4-1-20250805",
         "ClaudeApiKey": "your api key",
         "ClaudeWebSearchEnabled": true,
         "ClaudeTemperature": 0.2,
         "ClaudeMaxOutputTokens": 1200,
-        
         "MaxUploadMB": 25,
         "AllowedExtensions": [
             ".txt",

--- a/entry.ps1
+++ b/entry.ps1
@@ -190,6 +190,13 @@ switch ($module) {
     'store' {
         micro $storePath
     }
+    'sync' {
+        switch ($command) {
+            'upload' { & "$sysFolder\sync.ps1" -Action upload }
+            'download' { & "$sysFolder\sync.ps1" -Action download }
+            default { Write-Warning "Unknown sync action. Use: upload | download" }
+        }
+    }
     'sys' {
         switch ($command) {
             'shutdown' { & "$sysFolder\shutdown.ps1" $extraArgs }

--- a/scripts/win/system/note.ps1
+++ b/scripts/win/system/note.ps1
@@ -100,7 +100,7 @@ function Pick-NoteWithAction([pscustomobject[]]$Items, [string]$Prompt='notes> '
 
   $previewCmd = 'powershell -NoProfile -Command "try { Get-Content -LiteralPath ''{3}'' -Raw } catch { Write-Output '''' }"'
 
-  $fzfArgs = @(
+$fzfArgs = @(
     '--delimiter', "`t",
     '--with-nth=1,2',
     '--prompt', $Prompt,
@@ -108,7 +108,8 @@ function Pick-NoteWithAction([pscustomobject[]]$Items, [string]$Prompt='notes> '
     '--layout', 'reverse',
     '--ansi',
     '--preview', $previewCmd,
-    '--preview-window', 'right,60%,border-rounded,wrap',
+    '--preview-window', 'hidden:border-rounded,wrap',  # keep preview available, but hidden
+    '--bind', 'alt-p:toggle-preview,ctrl-p:toggle-preview', # toggle if you want it
     '--expect', 'enter,del,backspace'
   )
 

--- a/scripts/win/system/sync.ps1
+++ b/scripts/win/system/sync.ps1
@@ -1,0 +1,110 @@
+# scripts/win/central/sync.ps1
+# Mirrors configured folders between local station and the shared NetworkRoot.
+# Usage:
+#   borg config upload            # local -> hub (NetworkRoot)
+#   borg config download          # hub   -> local
+#   borg config upload <name>     # just one folder
+#   borg config download <name>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [ValidateSet('upload','download')]
+  [string]$Action,
+
+  [string]$Name = 'all'
+)
+
+# Load borg helpers (expects: Get-BorgStore, GetBorgStoreValue, Resolve-EnvTokens)
+. "$env:BORG_ROOT\config\globalfn.ps1"
+
+function New-DirIfMissing([string]$Path) {
+  if (-not [string]::IsNullOrWhiteSpace($Path) -and -not (Test-Path -LiteralPath $Path)) {
+    New-Item -ItemType Directory -Force -Path $Path | Out-Null
+  }
+}
+
+# --- Read config (via new cached accessor) ---
+$store  = Get-BorgStore
+$sync   = $store.Sync
+if (-not $sync) { throw "Missing 'Sync' section in store.json." }
+
+$networkRoot = GetBorgStoreValue -Chapter Sync -Key 'General.NetworkRoot' -ExpandEnv
+if ([string]::IsNullOrWhiteSpace($networkRoot)) {
+  throw "Sync.General.NetworkRoot is required."
+}
+
+# Ensure robocopy exists
+if (-not (Get-Command robocopy.exe -ErrorAction SilentlyContinue)) {
+  throw "robocopy.exe not found in PATH. Please ensure it's available."
+}
+
+# Collect folders (optionally filtered)
+$folders = @($sync.Folders)
+if (-not $folders -or $folders.Count -eq 0) { throw "No Sync.Folders defined." }
+
+if ($Name -ne 'all') {
+  $folders = $folders | Where-Object { $_.Name -eq $Name }
+  if (-not $folders -or $folders.Count -eq 0) { throw "Sync folder '$Name' not found." }
+}
+
+foreach ($f in $folders) {
+  # Resolve local path using new env expander from globalfn
+  $localPath = ($f.Local | Resolve-EnvTokens)
+  if ([string]::IsNullOrWhiteSpace($localPath) -or -not (Test-Path -LiteralPath $localPath)) {
+    Write-Warning "Skip '$($f.Name)': local path missing or not found: $localPath"
+    continue
+  }
+
+  $remoteRel  = if ($f.Remote) { $f.Remote } else { $f.Name }
+  $remotePath = Join-Path $networkRoot $remoteRel
+  New-DirIfMissing $remotePath
+
+  if ($Action -eq 'upload') { $src = $localPath;  $dst = $remotePath }
+  else                      { $src = $remotePath; $dst = $localPath  }
+
+  # Map excludes:
+  #   '*.log'   -> /XF
+  #   'logs\**' -> /XD logs
+  $exFiles = @()
+  $exDirs  = @()
+  foreach ($pat in ($f.Exclude ?? @())) {
+    if ($pat -like '*\**') {
+      $exDirs += ($pat -replace '\\\*\*$','')
+    } else {
+      $exFiles += $pat
+    }
+  }
+
+  Write-Host ""
+  Write-Host ("🔁 {0}  [{1}]" -f $Action.ToUpper(), $f.Name) -ForegroundColor Cyan
+  Write-Host "    From: $src"
+  Write-Host "    To:   $dst"
+
+  # Ensure destination exists
+  New-DirIfMissing $dst
+
+  # Build robocopy args (mirror; one retry; no wait)
+  $args = @(
+    $src, $dst,
+    '/MIR',        # mirror (includes deletions)
+    '/Z',          # restartable mode
+    '/R:1',        # one retry
+    '/W:0',        # no wait
+    '/COPY:DAT',   # file data, attributes, timestamps
+    '/DCOPY:DAT',  # dir data, attributes, timestamps
+    '/NFL','/NDL','/NP'  # cleaner output
+  )
+  if ($exFiles.Count) { $args += @('/XF') + $exFiles }
+  if ($exDirs.Count)  { $args += @('/XD') + $exDirs  }
+
+  $proc = Start-Process -FilePath robocopy.exe -ArgumentList $args -PassThru -Wait
+  $code = $proc.ExitCode
+
+  # robocopy: 0–7 = success-ish; >=8 = failure
+  if ($code -ge 8) {
+    Write-Warning "robocopy failed with code $code for [$($f.Name)]."
+  } else {
+    Write-Host "✅ Done (code $code)." -ForegroundColor Green
+  }
+}


### PR DESCRIPTION
### 🔄 Synchronizing Configuration Across Stations

The **Sync** system allows you to keep your Borg setup consistent across multiple stations — for example, between **Thanatos** and **MasterChief** — using a shared network folder as a central hub.

#### How It Works
The mechanism is defined under the `Sync` section in your `store.json` and includes:
- A single **NetworkRoot**: the shared location (e.g., `\\SERVER\Share\BorgHub`) that acts as the central repository.
- A list of **Folders**: each maps a local path on your station to a relative subfolder inside the `NetworkRoot`.

When you run:
```powershell
borg sync upload
```
Borg mirrors your local folders to the shared network hub (overwriting the remote copies).  
When you run:
```powershell
borg sync download
```
it mirrors the shared hub contents back to your local station.

This makes it effortless to move between workstations while preserving notes, ideas, configurations, and custom scripts.

#### Example `store.json` Section
```jsonc
"Sync": {
  "General": {
    "NetworkRoot": "\\someremote\somesharedfolder"
  },
  "Folders": [
    {
      "Name": "borg-appdata",
      "Local": "%APPDATA%\\Borg",
      "Remote": "appdata",
      "Exclude": ["*.log", "temp\\**", "logs\\**"]
    },
    {
      "Name": "custom-scripts",
      "Local": "C:\\custom-scripts",
      "Remote": "custom-scripts"
    }
  ]
}
```

#### Notes
- Borg uses **robocopy** internally for maximum reliability, one retry (`/R:1`) and zero wait (`/W:0`).
- The operation includes deletions to maintain an exact mirror.
- Exclude patterns help skip logs, temporary folders, or transient files.
- No extra software is required — it runs entirely through PowerShell.